### PR TITLE
Fix build failures on ARM (M1/M2) and Node 17+

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,6 @@ module.exports = {
   pathPrefix: `/fullstack-for-frontend3/`,
   plugins: [
     'gatsby-theme-docz',
-    `gatsby-transformer-sharp`,
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "homepage": "https://github.com/young/fullstack-for-frontend3#readme",
   "scripts": {
-    "dev": "gatsby develop",
-    "build": "gatsby build --prefix-paths",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider gatsby develop",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider gatsby build --prefix-paths",
     "publish": "rm -rf docs && mv ./public ./docs",
     "serve": "gatsby serve"
   },
@@ -18,9 +18,7 @@
     "docz": "^2.0.0-rc.76",
     "gatsby": "^2.13.73",
     "gatsby-plugin-offline": "^2.2.7",
-    "gatsby-plugin-sharp": "^2.2.18",
     "gatsby-theme-docz": "latest",
-    "gatsby-transformer-sharp": "^2.2.7",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",


### PR DESCRIPTION


- Removes `gatsby-plugin-sharp` and `gatsby-transformer-sharp` 


Fixes #2

